### PR TITLE
Add win dev server, fix #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "PORT=4000 gulp dev"
+    "dev": "PORT=4000 gulp dev",
+    "windev:" "set PORT=4000 && gulp dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add dev server for windows.
Now you can run 'npm run windev' on windows to start a dev server.